### PR TITLE
Fix UUID query casting, translation in generated output

### DIFF
--- a/scripts/entity-generation/2-create-entity-types.ts
+++ b/scripts/entity-generation/2-create-entity-types.ts
@@ -250,6 +250,9 @@ for (const {
   entityType,
   metadata: { domain, module },
 } of results) {
+  await mkdir(path.resolve(args.values.out, 'entity-types', domain, module), { recursive: true });
+  await write('entity-types', domain, module, `${entityType.name}.json5`, json5.stringify(entityType, null, 2));
+
   for (const column of entityType.columns ?? []) {
     column.labelAlias = translationsByLocale.get('en')![`entityType.${entityType.name}.${column.name}`];
 
@@ -261,8 +264,6 @@ for (const {
     }
   }
 
-  await mkdir(path.resolve(args.values.out, 'entity-types', domain, module), { recursive: true });
-  await write('entity-types', domain, module, `${entityType.name}.json5`, json5.stringify(entityType, null, 2));
   await write(
     'csv',
     domain,

--- a/src/schema-conversion/field-processing/data-type.test.ts
+++ b/src/schema-conversion/field-processing/data-type.test.ts
@@ -177,13 +177,12 @@ describe('getDataType', () => {
             dataType: {
               dataType: 'rangedUUIDType',
             },
-            filterValueGetter:
-              "(SELECT array_agg(lower(elems.value->>'bar')) FROM jsonb_array_elements(:sauce.jsonb) AS elems)",
             name: 'bar',
             property: 'bar',
             queryable: true,
-            valueFunction: 'lower(:value)',
-            valueGetter: "(SELECT array_agg(elems.value->>'bar') FROM jsonb_array_elements(:sauce.jsonb) AS elems)",
+            valueFunction: '(:value)::uuid',
+            valueGetter:
+              "(SELECT array_agg((elems.value->>'bar')::uuid) FROM jsonb_array_elements(:sauce.jsonb) AS elems)",
             visibleByDefault: false,
           },
         ],

--- a/src/schema-conversion/field-processing/getters.ts
+++ b/src/schema-conversion/field-processing/getters.ts
@@ -38,10 +38,11 @@ export function getGetterOverrides(schema: JSONSchema7): GetterOverrides {
   return overrides;
 }
 
-const CAST_OPTIONS = { [DataTypeValue.integerType]: 'integer', [DataTypeValue.numberType]: 'float' } as Record<
-  DataTypeValue,
-  string | undefined
->;
+const CAST_OPTIONS = {
+  [DataTypeValue.integerType]: 'integer',
+  [DataTypeValue.numberType]: 'float',
+  [DataTypeValue.rangedUUIDType]: 'uuid',
+} as Record<DataTypeValue, string | undefined>;
 
 function getCast(dataType: DataTypeValue) {
   return CAST_OPTIONS[dataType];

--- a/test/entity-types/simple_department.json
+++ b/test/entity-types/simple_department.json
@@ -19,7 +19,8 @@
       "isIdColumn": true,
       "queryable": true,
       "visibleByDefault": false,
-      "valueGetter": ":department.id"
+      "valueGetter": ":department.id",
+      "valueFunction": "(:value)::uuid"
     },
     {
       "name": "name",
@@ -83,7 +84,8 @@
       },
       "queryable": true,
       "visibleByDefault": false,
-      "valueGetter": ":department.jsonb->'metadata'->>'createdByUserId'"
+      "valueFunction": "(:value)::uuid",
+      "valueGetter": "(:department.jsonb->'metadata'->>'createdByUserId')::uuid"
     },
     {
       "name": "metadata_created_by_username",
@@ -110,7 +112,8 @@
       },
       "queryable": true,
       "visibleByDefault": false,
-      "valueGetter": ":department.jsonb->'metadata'->>'updatedByUserId'"
+      "valueFunction": "(:value)::uuid",
+      "valueGetter": "(:department.jsonb->'metadata'->>'updatedByUserId')::uuid"
     },
     {
       "name": "metadata_updated_by_username",


### PR DESCRIPTION
This adds two changes to generation:

- Fix regression that caused translations' `labelAlias` to leak into generated entity types
- UUID fields (`dataType === rangedUUIDType`) now use simpler casted getters

Old getters:
```js
{
  valueGetter: `:${entityType.source}.jsonb${fullPath}`,
  // for RMB only, omitted otherwise
  filterValueGetter: `lower($\{tenant_id}_${snakeCase(config.metadata.module)}.f_unaccent(:${entityType.source}.jsonb${fullPath}::text))`,
  valueFunction: `lower($\{tenant_id}_${snakeCase(config.metadata.module)}.f_unaccent(:value))`,
}
```

New:
```
{
  valueGetter: `(:${entityType.source}.jsonb${fullPath})::${cast}`,
  valueFunction: `(:value)::${cast}`,
}
```