### PR TITLE
Add option to make all generated entity types public

### DIFF
--- a/.github/workflows/generate-entity-types.yaml
+++ b/.github/workflows/generate-entity-types.yaml
@@ -14,6 +14,11 @@ on:
         required: false
         default: false
         type: boolean
+      force-public:
+        description: 'If all entity types should be marked as public (visible in the Lists app)'
+        required: false
+        default: false
+        type: boolean
       base-branch:
         description: 'Branch of `mod-fqm-manager` to use as a base for the PR or `master` if empty'
         required: false
@@ -38,6 +43,7 @@ on:
         required: false
         default: true
         type: boolean
+
   workflow_call:
     inputs:
       repository-list:
@@ -45,6 +51,10 @@ on:
         default: ''
         type: string
       force-generate-joins:
+        required: false
+        default: false
+        type: boolean
+      force-public:
         required: false
         default: false
         type: boolean
@@ -58,7 +68,6 @@ on:
         required: true
         type: string
       send-slack:
-        description: If Slack messages should be sent alerting about the PR creation and any team's issues
         required: true
         type: boolean
 
@@ -87,7 +96,11 @@ jobs:
 
       - name: Force join generation (if enabled)
         if: ${{ inputs.force-generate-joins == 'true' }}
-        run: echo "--force-generate-joins" >> extra-params.txt
+        run: echo " --force-generate-joins " >> extra-params.txt
+
+      - name: Force public entity types (if enabled)
+        if: ${{ inputs.force-public == 'true' }}
+        run: echo " --force-public " >> extra-params.txt
 
       - name: Run generation
         run: |

--- a/.github/workflows/scheduled-entity-type-creation.yaml
+++ b/.github/workflows/scheduled-entity-type-creation.yaml
@@ -6,7 +6,7 @@ on:
     - cron: '0 */3 * * *'
 
 jobs:
-  test:
+  scheduled-generate:
     uses: ./.github/workflows/generate-entity-types.yaml
     secrets: inherit
     with:

--- a/scripts/entity-generation/2-create-entity-types.ts
+++ b/scripts/entity-generation/2-create-entity-types.ts
@@ -37,6 +37,10 @@ const args = parseArgs({
       type: 'boolean',
       default: false,
     },
+    'force-public': {
+      type: 'boolean',
+      default: false,
+    },
   },
   strict: true,
   allowPositionals: true,
@@ -53,6 +57,7 @@ if (args.values.help) {
   console.log('  -h, --help              Show this help message');
   console.log('  -o, --out               Output directory (default: out)');
   console.log('  --force-generate-joins  [dev only] Force generation of joins even if no matching target is found.');
+  console.log('  --force-public          [dev only] Mark all entity types as public (visible via the Lists app).');
   console.log('                          Will fill dummy data in for target ET/fields, to enable result verification.');
   process.exit(1);
 }
@@ -250,7 +255,10 @@ for (const {
   entityType,
   metadata: { domain, module },
 } of results) {
-  await mkdir(path.resolve(args.values.out, 'entity-types', domain, module), { recursive: true });
+  if (args.values['force-public']) {
+    entityType.private = false;
+  }
+
   await write('entity-types', domain, module, `${entityType.name}.json5`, json5.stringify(entityType, null, 2));
 
   for (const column of entityType.columns ?? []) {


### PR DESCRIPTION
This adds an option to the manual generation to mark all generated entity types as public. This should make it a little easier to test in Rancher (we can run this, have it push to `automated-staging-rancher` or something, and then deploy that instead of having to set `private: false` every time
<img width="337" height="741" alt="image" src="https://github.com/user-attachments/assets/a3af0af7-52bb-4c53-9c1c-a7569de4560a" />
