### PR TITLE
[FQMTOOL-14] Mark array-object fields as queryable by default

### DIFF
--- a/src/schema-conversion/entity-type/entity-type.ts
+++ b/src/schema-conversion/entity-type/entity-type.ts
@@ -6,7 +6,6 @@ import {
   ensureNestedObjectsAreProperForm,
   getJsonbField,
   inferFieldFromSchema,
-  markNestedArrayOfObjectsNonQueryable,
   removeNestedFieldDisallowedProperties,
   unpackObjectColumns,
 } from '../field-processing/field';
@@ -34,9 +33,7 @@ export default function createEntityTypeFromConfig(
 
   const completedColumns = applyOverrides(
     ensureNestedObjectsAreProperForm(
-      markNestedArrayOfObjectsNonQueryable(
-        removeNestedFieldDisallowedProperties(unpackObjectColumns([...baseColumns, ...getJsonbField(entityType)])),
-      ),
+      removeNestedFieldDisallowedProperties(unpackObjectColumns([...baseColumns, ...getJsonbField(entityType)])),
     ),
     entityType['fieldOverrides'],
   );

--- a/src/schema-conversion/entity-type/entity-type.ts
+++ b/src/schema-conversion/entity-type/entity-type.ts
@@ -6,6 +6,7 @@ import {
   ensureNestedObjectsAreProperForm,
   getJsonbField,
   inferFieldFromSchema,
+  markNestedArrayOfObjectsNonQueryable,
   removeNestedFieldDisallowedProperties,
   unpackObjectColumns,
 } from '../field-processing/field';
@@ -33,7 +34,9 @@ export default function createEntityTypeFromConfig(
 
   const completedColumns = applyOverrides(
     ensureNestedObjectsAreProperForm(
-      removeNestedFieldDisallowedProperties(unpackObjectColumns([...baseColumns, ...getJsonbField(entityType)])),
+      markNestedArrayOfObjectsNonQueryable(
+        removeNestedFieldDisallowedProperties(unpackObjectColumns([...baseColumns, ...getJsonbField(entityType)])),
+      ),
     ),
     entityType['fieldOverrides'],
   );

--- a/src/schema-conversion/field-processing/field.test.ts
+++ b/src/schema-conversion/field-processing/field.test.ts
@@ -2,7 +2,7 @@ import { DataTypeValue, EntityTypeField, EntityTypeGenerationConfig } from '@/ty
 import { getGetters, getNestedGetters } from './getters';
 import { describe, expect, it } from 'bun:test';
 import { JSONSchema7 } from 'json-schema';
-import { ensureNestedObjectsAreProperForm, inferFieldFromSchema, markNestedArrayOfObjectsNonQueryable } from './field';
+import { ensureNestedObjectsAreProperForm, inferFieldFromSchema } from './field';
 
 const entityTypeConfig = { source: 'sauce' } as EntityTypeGenerationConfig['entityTypes'][number];
 const config = { metadata: { module: 'mod-foo' } } as EntityTypeGenerationConfig;
@@ -162,111 +162,6 @@ describe('getGetters', () => {
       filterValueGetter: "lower(${tenant_id}_mod_foo.f_unaccent(:sauce.jsonb->>'prop'::text))",
       valueFunction: 'lower(${tenant_id}_mod_foo.f_unaccent(:value))',
     });
-  });
-});
-
-describe('markNestedArrayOfObjectsNonQueryable', () => {
-  it('marks nested array of objects as non-queryable', () => {
-    const columns: EntityTypeField[] = [
-      {
-        name: 'column1',
-        dataType: {
-          dataType: DataTypeValue.arrayType,
-          itemDataType: {
-            dataType: DataTypeValue.objectType,
-            properties: [
-              {
-                name: 'nestedField',
-                dataType: { dataType: DataTypeValue.stringType },
-                queryable: true,
-              },
-            ],
-          },
-        },
-        queryable: true,
-      },
-    ];
-
-    const result = markNestedArrayOfObjectsNonQueryable(columns);
-
-    expect(result[0].dataType.itemDataType?.properties?.[0].queryable).toBe(false);
-  });
-
-  it('does not modify non-array or non-object fields', () => {
-    const columns: EntityTypeField[] = [
-      {
-        name: 'column1',
-        dataType: { dataType: DataTypeValue.stringType },
-        queryable: true,
-      },
-    ];
-
-    const result = markNestedArrayOfObjectsNonQueryable(columns);
-
-    expect(result).toEqual(columns);
-  });
-
-  it('handles deeply nested array->object structures', () => {
-    const columns: EntityTypeField[] = [
-      {
-        name: 'column1',
-        dataType: {
-          dataType: DataTypeValue.arrayType,
-          itemDataType: {
-            dataType: DataTypeValue.objectType,
-            properties: [
-              {
-                name: 'nestedArray',
-                dataType: {
-                  dataType: DataTypeValue.arrayType,
-                  itemDataType: {
-                    dataType: DataTypeValue.objectType,
-                    properties: [
-                      {
-                        name: 'deepField',
-                        dataType: { dataType: DataTypeValue.stringType },
-                        queryable: true,
-                      },
-                    ],
-                  },
-                },
-                queryable: true,
-              },
-            ],
-          },
-        },
-        queryable: true,
-      },
-    ];
-
-    const result = markNestedArrayOfObjectsNonQueryable(columns);
-
-    expect(result[0].dataType.itemDataType?.properties?.[0].dataType.itemDataType?.properties?.[0].queryable).toBe(
-      false,
-    );
-  });
-
-  it('does not modify fields without array->object structure', () => {
-    const columns: EntityTypeField[] = [
-      {
-        name: 'column1',
-        dataType: {
-          dataType: DataTypeValue.objectType,
-          properties: [
-            {
-              name: 'nestedField',
-              dataType: { dataType: DataTypeValue.stringType },
-              queryable: true,
-            },
-          ],
-        },
-        queryable: true,
-      },
-    ];
-
-    const result = markNestedArrayOfObjectsNonQueryable(columns);
-
-    expect(result).toEqual(columns);
   });
 });
 

--- a/src/schema-conversion/field-processing/field.test.ts
+++ b/src/schema-conversion/field-processing/field.test.ts
@@ -2,7 +2,7 @@ import { DataTypeValue, EntityTypeField, EntityTypeGenerationConfig } from '@/ty
 import { getGetters, getNestedGetters } from './getters';
 import { describe, expect, it } from 'bun:test';
 import { JSONSchema7 } from 'json-schema';
-import { ensureNestedObjectsAreProperForm, inferFieldFromSchema } from './field';
+import { ensureNestedObjectsAreProperForm, inferFieldFromSchema, markNestedArrayOfObjectsNonQueryable } from './field';
 
 const entityTypeConfig = { source: 'sauce' } as EntityTypeGenerationConfig['entityTypes'][number];
 const config = { metadata: { module: 'mod-foo' } } as EntityTypeGenerationConfig;
@@ -162,6 +162,117 @@ describe('getGetters', () => {
       filterValueGetter: "lower(${tenant_id}_mod_foo.f_unaccent(:sauce.jsonb->>'prop'::text))",
       valueFunction: 'lower(${tenant_id}_mod_foo.f_unaccent(:value))',
     });
+  });
+});
+
+describe('markNestedArrayOfObjectsNonQueryable', () => {
+  it('marks nested array of objects as non-queryable', () => {
+    const columns: EntityTypeField[] = [
+      {
+        name: 'column1',
+        dataType: {
+          dataType: DataTypeValue.arrayType,
+          itemDataType: {
+            dataType: DataTypeValue.objectType,
+            properties: [
+              {
+                name: 'nestedField',
+                dataType: { dataType: DataTypeValue.stringType },
+                queryable: true,
+              },
+              {
+                name: 'nestedField2',
+                dataType: { dataType: DataTypeValue.integerType },
+                queryable: true,
+              },
+            ],
+          },
+        },
+        queryable: true,
+      },
+    ];
+
+    const result = markNestedArrayOfObjectsNonQueryable(columns);
+
+    expect(result[0].dataType.itemDataType?.properties?.[0].queryable).toBeTrue();
+    expect(result[0].dataType.itemDataType?.properties?.[1].queryable).toBeFalse();
+  });
+
+  it('does not modify non-array or non-object fields', () => {
+    const columns: EntityTypeField[] = [
+      {
+        name: 'column1',
+        dataType: { dataType: DataTypeValue.stringType },
+        queryable: true,
+      },
+    ];
+
+    const result = markNestedArrayOfObjectsNonQueryable(columns);
+
+    expect(result).toEqual(columns);
+  });
+
+  it('handles deeply nested array->object structures', () => {
+    const columns: EntityTypeField[] = [
+      {
+        name: 'column1',
+        dataType: {
+          dataType: DataTypeValue.arrayType,
+          itemDataType: {
+            dataType: DataTypeValue.objectType,
+            properties: [
+              {
+                name: 'nestedArray',
+                dataType: {
+                  dataType: DataTypeValue.arrayType,
+                  itemDataType: {
+                    dataType: DataTypeValue.objectType,
+                    properties: [
+                      {
+                        name: 'deepField',
+                        dataType: { dataType: DataTypeValue.integerType },
+                        queryable: true,
+                      },
+                    ],
+                  },
+                },
+                queryable: true,
+              },
+            ],
+          },
+        },
+        queryable: true,
+      },
+    ];
+
+    const result = markNestedArrayOfObjectsNonQueryable(columns);
+
+    expect(result[0].dataType.itemDataType?.properties?.[0].dataType.itemDataType?.properties?.[0].queryable).toBe(
+      false,
+    );
+  });
+
+  it('does not modify fields without array->object structure', () => {
+    const columns: EntityTypeField[] = [
+      {
+        name: 'column1',
+        dataType: {
+          dataType: DataTypeValue.objectType,
+          properties: [
+            {
+              name: 'nestedField',
+              dataType: { dataType: DataTypeValue.integerType },
+              queryable: true,
+            },
+          ],
+        },
+        queryable: true,
+      },
+    ];
+
+    const result = markNestedArrayOfObjectsNonQueryable(columns);
+
+    expect(result).toEqual(columns);
   });
 });
 

--- a/src/schema-conversion/field-processing/field.ts
+++ b/src/schema-conversion/field-processing/field.ts
@@ -106,24 +106,6 @@ function recursiveFieldApplier(
   return result;
 }
 
-export function markNestedArrayOfObjectsNonQueryable(columns: EntityTypeField[]): EntityTypeField[] {
-  // temporarily mark all nested array of objects as non-queryable; see MODFQMMGR-740
-  return columns.map((column) => ({
-    ...column,
-    dataType: recursiveFieldApplier(column.dataType, [], (field, path) => {
-      // this will always be array->object as object->array gets flattened in unpackObjectColumns
-      if (path.includes('array') && path.includes('object')) {
-        return {
-          ...field,
-          queryable: false,
-        };
-      } else {
-        return field;
-      }
-    }),
-  }));
-}
-
 export function ensureNestedObjectsAreProperForm(columns: EntityTypeField[]): EntityTypeField[] {
   // all array->object fields must be arrayType->objectType, not jsonbArrayType->objectType.
   // generator currently spits out jsonbArrayType->objectType instead, so we must convert it.

--- a/src/schema-conversion/translations.ts
+++ b/src/schema-conversion/translations.ts
@@ -83,6 +83,9 @@ export function inferTranslationsFromField(
     translations[key] = sentenceCase(name);
     if (dt.dataType === DataTypeValue.rangedUUIDType) {
       translations[key] = translations[key].replace(/\bid\b/i, 'UUID');
+    } else {
+      translations[key] = translations[key].replace(/\bid\b/i, 'ID');
+      translations[key] = translations[key].replace(/\bids\b/i, 'IDs');
     }
     if (name === 'jsonb') {
       translations[key] = 'JSONB';

--- a/test/entity-types/simple_department.json
+++ b/test/entity-types/simple_department.json
@@ -142,7 +142,7 @@
               "filterValueGetter": "(SELECT array_agg(lower(elems.value->>'testString')) FROM jsonb_array_elements(:department.jsonb->'testArray') AS elems)",
               "name": "test_string",
               "property": "testString",
-              "queryable": false,
+              "queryable": true,
               "valueFunction": "lower(:value)",
               "valueGetter": "(SELECT array_agg(elems.value->>'testString') FROM jsonb_array_elements(:department.jsonb->'testArray') AS elems)"
             }


### PR DESCRIPTION
Huzzah, https://folio-org.atlassian.net/browse/MODFQMMGR-740 is done! (except we aren't sure how numeric values should be treated, so those still get relegated to non-queryable)