### PR TITLE
MODFQMMGR-1113 Allow ecsOnly flag for entityTypes.fieldAdditions and type/name for entityTypes.fieldAdditions source field

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -75,6 +75,8 @@ export const EntityTypeFieldTemplate = z
       .object({
         columnName: z.string(),
         entityTypeId: z.string(),
+        type: z.string().optional(),
+        name: z.string().optional(),
       })
       .optional(),
     valueSourceApi: z
@@ -92,6 +94,7 @@ export const EntityTypeFieldTemplate = z
         }),
       )
       .optional(),
+    ecsOnly: z.boolean().optional(),
     joinsTo: z.array(z.lazy(() => EntityTypeFieldJoinTemplate)).optional(), // Reference to EntityTypeFieldJoinTemplate
     joinsToIntermediate: z.array(z.lazy(() => EntityTypeFieldJoinIntermediateTemplate)).optional(),
   })


### PR DESCRIPTION
## Purpose
Authorities need shared/tenant_id/tenant_name properties defined via `[[entityTypes.fieldAdditions]]`
We also need `ecsOnly` flag for this fields as well as `type`/`name` for `[entityTypes.fieldAdditions.source]`

## Approach
Extend `EntityTypeFieldTemplate` with `ecsOnly` flag and `EntityTypeFieldTemplate.source` with `type`/`name` properties

## Related tickets
[MODELINKS-413](https://folio-org.atlassian.net/browse/MODELINKS-413)
[MODFQMMGR-1113](https://folio-org.atlassian.net/browse/MODFQMMGR-1113)