### PR TITLE
FQMTOOL-26 Block fields with both a source and valueSourceApi

### DIFF
--- a/src/schema-conversion/entity-type/entity-type.test.ts
+++ b/src/schema-conversion/entity-type/entity-type.test.ts
@@ -185,6 +185,75 @@ describe('createEntityTypeFromConfig', () => {
     expect(issues).toContainEqual('Excluded field test does not exist in the entity type');
   });
 
+  const SOURCE = { columnName: 'foo', entityTypeId: '00000000-0000-0000-0000-000000000000' };
+  const VALUE_SOURCE_API = { path: 'p', valueJsonPath: '$.id', labelJsonPath: '$.name' };
+
+  function generateWithFieldAdditions(fieldAdditions: object[]) {
+    return createEntityTypeFromConfig(
+      {
+        name: 'simple_department',
+        source: 'department',
+        schema: 'test/schemas/department.json',
+        permissions: ['perm1', 'perm2'],
+        sort: ['id', 'ASC'],
+        private: true,
+        includeJsonbField: false,
+        fieldAdditions,
+      } as EntityTypeGenerationConfig['entityTypes'][number],
+      { type: 'object', properties: {} } as JSONSchema7,
+      {
+        metadata: { module: 'foo' },
+        sources: [{ name: 'department', view: 'marinara' }],
+      } as unknown as EntityTypeGenerationConfig,
+    );
+  }
+
+  it('fails when a top-level field defines both source and valueSourceApi', () => {
+    expect(() =>
+      generateWithFieldAdditions([
+        {
+          name: 'conflicting',
+          dataType: { dataType: DataTypeValue.stringType },
+          source: SOURCE,
+          valueSourceApi: VALUE_SOURCE_API,
+        },
+      ]),
+    ).toThrowError(/simple_department.*\bconflicting\b/);
+  });
+
+  it('fails when a nested field defines both, reporting the full path', () => {
+    expect(() =>
+      generateWithFieldAdditions([
+        {
+          name: 'parent',
+          dataType: {
+            dataType: DataTypeValue.arrayType,
+            itemDataType: {
+              dataType: DataTypeValue.objectType,
+              properties: [
+                {
+                  name: 'child',
+                  dataType: { dataType: DataTypeValue.stringType },
+                  source: SOURCE,
+                  valueSourceApi: VALUE_SOURCE_API,
+                },
+              ],
+            },
+          },
+        },
+      ]),
+    ).toThrowError(/simple_department.*\bparent\.child\b/);
+  });
+
+  it('passes when fields define only source or only valueSourceApi', () => {
+    expect(() =>
+      generateWithFieldAdditions([
+        { name: 'only_source', dataType: { dataType: DataTypeValue.stringType }, source: SOURCE },
+        { name: 'only_api', dataType: { dataType: DataTypeValue.stringType }, valueSourceApi: VALUE_SOURCE_API },
+      ]),
+    ).not.toThrow();
+  });
+
   it('overrides add and update fields as applicable', async () => {
     expect(
       createEntityTypeFromConfig(

--- a/src/schema-conversion/entity-type/entity-type.ts
+++ b/src/schema-conversion/entity-type/entity-type.ts
@@ -1,4 +1,4 @@
-import { EntityType, EntityTypeField, EntityTypeGenerationConfig, EntityTypeSource } from '@/types';
+import { DataType, EntityType, EntityTypeField, EntityTypeGenerationConfig, EntityTypeSource } from '@/types';
 import { snakeCase } from 'change-case';
 import { JSONSchema7 } from 'json-schema';
 import { v5 } from 'uuid';
@@ -43,6 +43,8 @@ export default function createEntityTypeFromConfig(
 
   const [columns, exclusionIssues] = applyExclusions(completedColumns, entityType['fieldExclusions']);
   issues.push(...exclusionIssues);
+
+  validateNoSourceValueSourceApiConflict(entityType.name, columns);
 
   return {
     entityType: {
@@ -107,4 +109,34 @@ function applyExclusions(fields: EntityTypeField[], exclusions?: string[]): [Ent
   });
 
   return [Array.from(fieldMap.values()), issues];
+}
+
+/** Collects all nested fields of a data type, descending through object and array data types. */
+function nestedFieldsOf(dataType: DataType): EntityTypeField[] {
+  return [...(dataType.properties ?? []), ...(dataType.itemDataType ? nestedFieldsOf(dataType.itemDataType) : [])];
+}
+
+/**
+ * Rejects any field (top-level or nested) defining both `source` and `valueSourceApi`, which is
+ * ambiguous: each owns value retrieval on its own, so a field should define at most one.
+ *
+ * @throws Error identifying the entity type and field path of the first violation.
+ */
+function validateNoSourceValueSourceApiConflict(
+  entityTypeName: string,
+  fields: EntityTypeField[],
+  path: string[] = [],
+): void {
+  for (const field of fields) {
+    const fieldPath = [...path, field.name];
+
+    if (field.source && field.valueSourceApi) {
+      throw new Error(
+        `Entity type ${entityTypeName} field ${fieldPath.join('.')} defines both source and valueSourceApi; ` +
+          'a field may define at most one of these.',
+      );
+    }
+
+    validateNoSourceValueSourceApiConflict(entityTypeName, nestedFieldsOf(field.dataType), fieldPath);
+  }
 }


### PR DESCRIPTION
These two properties are mutually exclusive, so having both in a single field is confusing. This commit prevents fields from using both at the same time.