### PR TITLE
FQMTOOL-26 Remove sanitizing for source+valueSourceApi on fields

### DIFF
--- a/src/schema-conversion/entity-type/entity-type.test.ts
+++ b/src/schema-conversion/entity-type/entity-type.test.ts
@@ -254,6 +254,34 @@ describe('createEntityTypeFromConfig', () => {
     ).not.toThrow();
   });
 
+  it('fails when a schema property defines both x-fqm-source and x-fqm-value-source-api', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        conflicting: { type: 'string', 'x-fqm-source': SOURCE, 'x-fqm-value-source-api': VALUE_SOURCE_API },
+      },
+    } as JSONSchema7;
+
+    const entityType = {
+      name: 'simple_department',
+      source: 'department',
+      schema: 'inline',
+      permissions: ['perm1', 'perm2'],
+      sort: ['id', 'ASC'],
+      private: true,
+    } satisfies EntityTypeGenerationConfig['entityTypes'][number];
+
+    const config = {
+      metadata: { team: 'corsair', domain: 'users', module: 'foo' },
+      sources: [{ name: 'department', table: 'marinara' }],
+      entityTypes: [entityType],
+    } satisfies EntityTypeGenerationConfig;
+
+    expect(() => createEntityTypeFromConfig(entityType, schema, config)).toThrowError(
+      /simple_department.*\bconflicting\b/,
+    );
+  });
+
   it('overrides add and update fields as applicable', async () => {
     expect(
       createEntityTypeFromConfig(

--- a/src/schema-conversion/field-processing/extra-properties.test.ts
+++ b/src/schema-conversion/field-processing/extra-properties.test.ts
@@ -21,18 +21,20 @@ describe('getIsIdColumn', () => {
 });
 
 describe('getExtraProperties', () => {
+  const valueSourceApi = { path: 'some/path', valueJsonPath: '$.id', labelJsonPath: '$.name' };
+
   it('should return valueSourceApi when x-fqm-value-source-api is present', () => {
-    const schema = { 'x-fqm-value-source-api': 'api-source' } as JSONSchema7;
+    const schema = { 'x-fqm-value-source-api': valueSourceApi } as JSONSchema7;
     const result = getExtraProperties(schema);
-    expect(result.extraProperties.valueSourceApi as unknown).toBe('api-source');
+    expect(result.extraProperties.valueSourceApi).toBe(valueSourceApi);
   });
 
-  it('should not return valueSourceApi when x-fqm-source is present', () => {
+  it('should return both source and valueSourceApi when both are present (rejected later at the ET level)', () => {
     const source = { entityTypeId: 'customEntityTypeId', columnName: 'customColumnName' };
-    const schema = { 'x-fqm-source': source, 'x-fqm-value-source-api': 'api-source' } as JSONSchema7;
+    const schema = { 'x-fqm-source': source, 'x-fqm-value-source-api': valueSourceApi } as JSONSchema7;
     const result = getExtraProperties(schema);
     expect(result.extraProperties.source).toBe(source);
-    expect(result.extraProperties.valueSourceApi).toBeUndefined();
+    expect(result.extraProperties.valueSourceApi).toBe(valueSourceApi);
   });
 
   it('should return values when x-fqm-values is present', () => {

--- a/src/schema-conversion/field-processing/extra-properties.ts
+++ b/src/schema-conversion/field-processing/extra-properties.ts
@@ -94,7 +94,9 @@ export function getExtraProperties(propSchema: JSONSchema7) {
     extraProperties.values = propSchema['x-fqm-values'] as EntityTypeField['values'];
   }
 
-  if ('x-fqm-value-source-api' in propSchema && !('x-fqm-source' in propSchema)) {
+  if ('x-fqm-value-source-api' in propSchema) {
+    // passed through even alongside source; ET generation rejects that combination via
+    // validateNoSourceValueSourceApiConflict (other callers, e.g. the importer preview, do not)
     extraProperties.valueSourceApi = propSchema['x-fqm-value-source-api'] as EntityTypeField['valueSourceApi'];
   }
 


### PR DESCRIPTION
This was removing the source property, preventing the later check for both from failing. We want this to fail loudly, rather than silently change it, so that the object schemas are more in-sync with the generated entity types.